### PR TITLE
Use JSON output

### DIFF
--- a/api/v1/results.go
+++ b/api/v1/results.go
@@ -1,0 +1,59 @@
+package v1
+
+type Report struct {
+	// Defines the version of the result format.
+	Version string `json:"version" yaml:"version"`
+	// Overall defines the overall status.
+	Overall ResultStatus `json:"overall" yaml:"overall"`
+	// Details contains the details of the result.
+	Results []*ContextualResult `json:"results" yaml:"results"`
+}
+
+func (r *Report) AddResult(cr *ContextualResult) {
+	r.Results = append(r.Results, cr)
+}
+
+func (r *Report) GatherOverall() {
+	overall := ResultStatusPass
+	for _, cr := range r.Results {
+		for _, result := range cr.Results {
+			if result.Status == ResultStatusError {
+				r.Overall = ResultStatusError
+				return
+			}
+			if result.Status == ResultStatusFail {
+				overall = ResultStatusFail
+			}
+		}
+	}
+
+	r.Overall = overall
+}
+
+// Specifies a result for a single context.
+type ContextualResult struct {
+	// Defines the version of the result format.
+	Version string   `json:"version" yaml:"version"`
+	Target  string   `json:"target" yaml:"target"`
+	Results []Result `json:"results" yaml:"results"`
+}
+
+func (r *ContextualResult) AddResult(result Result) {
+	// TODO: Generate ID.
+	r.Results = append(r.Results, result)
+}
+
+type ResultStatus string
+
+const (
+	ResultStatusPass  ResultStatus = "pass"
+	ResultStatusFail  ResultStatus = "fail"
+	ResultStatusError ResultStatus = "error"
+)
+
+type Result struct {
+	ID           string       `json:"id"`
+	Name         string       `json:"name"`
+	Status       ResultStatus `json:"status"`
+	ErrorMessage string       `json:"errorMessage,omitempty"`
+}

--- a/go.sum
+++ b/go.sum
@@ -1124,7 +1124,6 @@ golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20220107192237-5cfca573fb4d h1:62NvYBuaanGXR2ZOfwDFkhhl6X1DUgf8qg3GuQvxZsE=
 golang.org/x/net v0.0.0-20220107192237-5cfca573fb4d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
@@ -1142,7 +1141,6 @@ golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 h1:OSnWWcOd/CtWQC2cYSBgbTSJv3ciqd8r54ySIW2y3RE=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
@@ -1264,8 +1262,8 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/runner/git/git.go
+++ b/pkg/runner/git/git.go
@@ -39,7 +39,7 @@ func (gr *gitRunner) Next(ctx context.Context) (rif.TargetEval, error) {
 		return nil, rif.ErrEndOfTargets
 	}
 
-	return func(ctx context.Context) error {
+	return func(ctx context.Context) (*apiv1.ContextualResult, error) {
 		return gr.HandleGit(ctx, repoRef, gr.ts, map[string]interface{}{})
 	}, nil
 }

--- a/pkg/runner/gitcommon/gitcommon.go
+++ b/pkg/runner/gitcommon/gitcommon.go
@@ -1,6 +1,7 @@
 package gitcommon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -51,10 +52,15 @@ func (gc *GitCommon) TearDownCommon(ctx context.Context) error {
 	return nil
 }
 
-func (gc *GitCommon) HandleGit(ctx context.Context, gd *apiv1.GitDefinition, ts *apiv1.TrickSet, input any) error {
+func (gc *GitCommon) HandleGit(
+	ctx context.Context,
+	gd *apiv1.GitDefinition,
+	ts *apiv1.TrickSet,
+	input any,
+) (*apiv1.ContextualResult, error) {
 	targetDir, terr := ioutil.TempDir("", "bark-git-")
 	if terr != nil {
-		return fmt.Errorf("failed to create temp dir: %w", terr)
+		return nil, fmt.Errorf("failed to create temp dir: %w", terr)
 	}
 	gc.TrackFile(targetDir)
 
@@ -71,7 +77,7 @@ func (gc *GitCommon) HandleGit(ctx context.Context, gd *apiv1.GitDefinition, ts 
 	}
 	_, err := git.PlainCloneContext(ctx, targetDir, withWorktree, opts)
 	if err != nil {
-		return fmt.Errorf("could not clone repo: %w", err)
+		return nil, fmt.Errorf("could not clone repo: %w", err)
 	}
 
 	// this would be the environment
@@ -79,35 +85,53 @@ func (gc *GitCommon) HandleGit(ctx context.Context, gd *apiv1.GitDefinition, ts 
 
 	inputfile, terr := ioutil.TempFile("", "bark-input")
 	if terr != nil {
-		return fmt.Errorf("failed to create input file: %w", terr)
+		return nil, fmt.Errorf("failed to create input file: %w", terr)
 	}
 	defer inputfile.Close()
 	gc.TrackFile(inputfile.Name())
 
 	if eerr := json.NewEncoder(inputfile).Encode(map[string]string{}); eerr != nil {
-		return fmt.Errorf("failed to encode input: %w", eerr)
+		return nil, fmt.Errorf("failed to encode input: %w", eerr)
 	}
 
 	tsfile, terr := ioutil.TempFile("", "bark-ts")
 	if terr != nil {
-		return fmt.Errorf("failed to create temp trickset file: %w", terr)
+		return nil, fmt.Errorf("failed to create temp trickset file: %w", terr)
 	}
 	defer tsfile.Close()
 	gc.TrackFile(tsfile.Name())
 
 	if eerr := yaml.NewEncoder(tsfile).Encode(ts); eerr != nil {
-		return fmt.Errorf("failed to encode input: %w", eerr)
+		return nil, fmt.Errorf("failed to encode input: %w", eerr)
 	}
 
-	out, err := exec.Command(cmd, "bark",
+	var outsb, errsb bytes.Buffer
+
+	c := exec.Command(cmd, "bark",
 		"-i", inputfile.Name(),
 		"-t", tsfile.Name(),
+		"-x", getTargetString(gd.URL, gd.Branch),
 		"-r", targetDir,
-	).CombinedOutput()
-	fmt.Printf("repository: %s@%s\n", gd.URL, gd.Branch)
-	fmt.Printf("output: %s\n", out)
-	if err != nil {
+	)
+
+	c.Stdout = &outsb
+	c.Stderr = &errsb
+
+	if err := c.Run(); err != nil {
 		fmt.Printf("err: %s\n", err)
 	}
-	return nil
+
+	str := outsb.Bytes()
+
+	cr := &apiv1.ContextualResult{}
+	derr := json.Unmarshal(str, cr)
+	if derr != nil {
+		return nil, fmt.Errorf("failed to decode output: %w", derr)
+	}
+
+	return cr, nil
+}
+
+func getTargetString(url, branch string) string {
+	return fmt.Sprintf("%s@%s", url, branch)
 }

--- a/pkg/runner/github/github.go
+++ b/pkg/runner/github/github.go
@@ -66,7 +66,7 @@ func (gr *gitHubRunner) Next(ctx context.Context) (rif.TargetEval, error) {
 
 	grepo := githubRepoToRepoRef(repoInfo)
 
-	return func(ctx context.Context) error {
+	return func(ctx context.Context) (*apiv1.ContextualResult, error) {
 		// TODO(jaosorior): Add GitHub info as input
 		return gr.HandleGit(ctx, grepo, gr.ts, map[string]interface{}{})
 	}, nil

--- a/pkg/runner/runnerinterface/interface.go
+++ b/pkg/runner/runnerinterface/interface.go
@@ -3,11 +3,13 @@ package runnerinterface
 import (
 	"context"
 	"errors"
+
+	apiv1 "github.com/lammaskoira/bark/api/v1"
 )
 
 var ErrEndOfTargets = errors.New("end of targets")
 
-type TargetEval func(context.Context) error
+type TargetEval func(context.Context) (*apiv1.ContextualResult, error)
 
 type Runner interface {
 	Setup(context.Context) error


### PR DESCRIPTION
This replaces the debug-like status for a more structured and defined
JSON-based status that can be parsed by other tools.

Closes: #6
