### PR TITLE
Do a call per repository and add vulnerability alerts enablement support

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -27,29 +27,6 @@ type ContextDefinition struct {
 	GitHub   *GitHubDefinition `json:"github,omitempty" yaml:"github,omitempty"`
 }
 
-type GitDefinition struct {
-	URL    string `json:"url" yaml:"url"`
-	Branch string `json:"branch" yaml:"branch"`
-
-	// TODO(jaosorior): Add support for credentials
-}
-
-type GitHubDefinition struct {
-	// Org is the organization that owns the repos
-	Org string `json:"org" yaml:"org"`
-
-	// Branch to check for when evaluating the policy on repos
-	Branch string `json:"branch" yaml:"branch"`
-
-	// Override the default branch for a repo
-	Overrides []GitHubDefinition `json:"overrides,omitempty" yaml:"overrides,omitempty"`
-
-	// Exclude repos from the policy
-	Exclude []string `json:"exclude,omitempty" yaml:"exclude,omitempty"`
-
-	// TODO(jaosorior): Add support for credentials
-}
-
 type GithubRepoConfig struct {
 	Org string `json:"org" yaml:"org"`
 }

--- a/api/v1/git.go
+++ b/api/v1/git.go
@@ -1,0 +1,8 @@
+package v1
+
+type GitDefinition struct {
+	URL    string `json:"url" yaml:"url"`
+	Branch string `json:"branch" yaml:"branch"`
+
+	// TODO(jaosorior): Add support for credentials
+}

--- a/api/v1/github.go
+++ b/api/v1/github.go
@@ -1,0 +1,30 @@
+package v1
+
+type GitHubDefinition struct {
+	// Org is the organization that owns the repos
+	Org string `json:"org" yaml:"org"`
+
+	// Branch to check for when evaluating the policy on repos
+	Branch string `json:"branch" yaml:"branch"`
+
+	// Override the default branch for a repo
+	Overrides []GitHubDefinition `json:"overrides,omitempty" yaml:"overrides,omitempty"`
+
+	// Exclude repos from the policy
+	Exclude []string `json:"exclude,omitempty" yaml:"exclude,omitempty"`
+
+	// TODO(jaosorior): Add support for credentials
+}
+
+const (
+	// RepositoryMetadataInputKey is a key in the rego input will contain the metadata
+	// available for the given repository.
+	// The values come directly from the GitHub API [1]
+	// [1]: https://docs.github.com/en/rest/repos/repos#get-a-repository
+	RepositoryMetadataInputKey = "repometa"
+
+	// VulnerabilityAlertsEnabledInputKey is a key in the rego input
+	// that will contain a boolean that tells us whether vulnerability
+	// alerts are enabled for a given repository or not.
+	VulnerabilityAlertsEnabledInputKey = "vulnerability_alerts_enabled"
+)

--- a/pkg/runner/gitcommon/gitcommon.go
+++ b/pkg/runner/gitcommon/gitcommon.go
@@ -90,7 +90,7 @@ func (gc *GitCommon) HandleGit(
 	defer inputfile.Close()
 	gc.TrackFile(inputfile.Name())
 
-	if eerr := json.NewEncoder(inputfile).Encode(map[string]string{}); eerr != nil {
+	if eerr := json.NewEncoder(inputfile).Encode(input); eerr != nil {
 		return nil, fmt.Errorf("failed to encode input: %w", eerr)
 	}
 


### PR DESCRIPTION
In order to get more information on the repository, this now makes
individual GET calls to the GitHub API in order fill the metadata for
the repo.

This also now gets the status of whether vulnerability alerts are
enabled or not for a given repo.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
