### PR TITLE
Add support for verifying GitHub Organization configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,16 @@ There are two rules in this sample:
 
 ### Contexts
 
-Currently, there are two context types defined:
+Currently, the following contexts are defined:
 
 * `git`
 
 * `github`
+
+* `githubOrgConfig`
+
+
+#### git
 
 `git` is a context that is a single Git repository. It allows
 for specifying the Git URL and branch to verify. A sample looks as
@@ -94,6 +99,8 @@ context:
 One must always define the provider to be used, and specify the provider
 configuration in the context.
 
+#### github
+
 `github` is a context allows for evaluating policies on GitHub repositories.
 It allows for specifying the GitHub organization, which will verify all
 repositories in that organization. A sample looks as follows:
@@ -108,6 +115,39 @@ context:
 While running the `bark` program, you can specify a GitHub token to
 use for authentication. This is possible via the `GITHUB_TOKEN` environment
 variable.
+
+It's also possible to evaluate a policy against the repository metadata
+retrived from the GitHub API. The current implementation adds the following keys
+to the rego input:
+
+* `repometa`: The repository metadata from the GitHub API.
+  This comes from a [GET request to the GitHub API](https://docs.github.com/en/rest/repos/repos#get-a-repository).
+
+* `vulnerability_alerts_enabled`: It's a boolean that indicates if the repository
+  has the `vulnerability-alerts` feature enabled.
+
+#### githubOrgConfig
+
+`githubOrgConfig` is a context that allows for evaluating policies
+on GitHub organizations. It allows for specifying the GitHub organization
+to evaluate. A sample looks as follows:
+
+```yaml
+context:
+  provider: githubOrgConfig
+  githubOrgConfig:
+    org: lammaskoira
+```
+
+While running the `bark` program, you can specify a GitHub token to
+use for authentication. This is possible via the `GITHUB_TOKEN` environment
+variable.
+
+Policy evaluation relies entirely on the Organization information
+retrieved from the GitHub API. The current implementation adds the following keys:
+
+* `orgconfig`: The organization configuration from the GitHub API.
+  This comes from a [GET request to the GitHub API](https://docs.github.com/en/rest/reference/orgs#get-an-organization).
 
 ### Policy language
 

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -17,14 +17,16 @@ type TrickSet struct {
 type ValidContext string
 
 const (
-	GitContext    = ValidContext("git")
-	GitHubContext = ValidContext("github")
+	GitContext             = ValidContext("git")
+	GitHubContext          = ValidContext("github")
+	GitHubOrgConfigContext = ValidContext("githubOrgConfig")
 )
 
 type ContextDefinition struct {
-	Provider ValidContext      `json:"provider" yaml:"provider"`
-	Git      *GitDefinition    `json:"git,omitempty" yaml:"git,omitempty"`
-	GitHub   *GitHubDefinition `json:"github,omitempty" yaml:"github,omitempty"`
+	Provider        ValidContext               `json:"provider" yaml:"provider"`
+	Git             *GitDefinition             `json:"git,omitempty" yaml:"git,omitempty"`
+	GitHub          *GitHubDefinition          `json:"github,omitempty" yaml:"github,omitempty"`
+	GitHubOrgConfig *GitHubOrgConfigDefinition `json:"githubOrgConfig,omitempty" yaml:"githubOrgConfig,omitempty"`
 }
 
 type GithubRepoConfig struct {

--- a/api/v1/githuborgconfig.go
+++ b/api/v1/githuborgconfig.go
@@ -1,0 +1,10 @@
+package v1
+
+type GitHubOrgConfigDefinition struct {
+	// Org is the organization that owns the repos
+	Org string `json:"org" yaml:"org"`
+}
+
+const (
+	OrgConfigInputKey = "orgconfig"
+)

--- a/api/v1/validation.go
+++ b/api/v1/validation.go
@@ -1,6 +1,8 @@
 package v1
 
-import "fmt"
+import (
+	"fmt"
+)
 
 func (ts *TrickSet) Validate() error {
 	if ts.GetVersion() != Version {
@@ -26,6 +28,10 @@ func (ts *TrickSet) ValidateContext() error {
 		}
 	case GitHubContext:
 		if ts.Context.GitHub != nil {
+			return nil
+		}
+	case GitHubOrgConfigContext:
+		if ts.Context.GitHubOrgConfig != nil {
 			return nil
 		}
 	default:

--- a/pkg/runner/gitcommon/gitcommon.go
+++ b/pkg/runner/gitcommon/gitcommon.go
@@ -23,8 +23,8 @@ const (
 )
 
 type GitCommon struct {
-	filesToClean *util.Stack[string]
-	accessToken  string
+	accessToken string
+	util.FileTracker
 }
 
 func (gc *GitCommon) SetAccessToken(tok string) {
@@ -36,20 +36,11 @@ func (gc *GitCommon) GetAccessToken() string {
 }
 
 func (gc *GitCommon) SetupCommon(ctx context.Context) {
-	gc.filesToClean = util.NewStack[string]()
-}
-
-func (gc *GitCommon) TrackFile(file string) {
-	gc.filesToClean.Push(file)
+	gc.SetupFileTracker()
 }
 
 func (gc *GitCommon) TearDownCommon(ctx context.Context) error {
-	for !gc.filesToClean.IsEmpty() {
-		if err := os.RemoveAll(gc.filesToClean.Pop()); err != nil {
-			return err
-		}
-	}
-	return nil
+	return gc.TearDownFileTracker(ctx)
 }
 
 func (gc *GitCommon) HandleGit(

--- a/pkg/runner/github/github.go
+++ b/pkg/runner/github/github.go
@@ -3,21 +3,14 @@ package github
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"os"
 
 	gh "github.com/google/go-github/v44/github"
-	"golang.org/x/oauth2"
 
 	apiv1 "github.com/lammaskoira/bark/api/v1"
 	"github.com/lammaskoira/bark/pkg/runner/gitcommon"
+	"github.com/lammaskoira/bark/pkg/runner/githubcommon"
 	rif "github.com/lammaskoira/bark/pkg/runner/runnerinterface"
 	"github.com/lammaskoira/bark/pkg/util"
-)
-
-const (
-	// nolint:gosec // This is a constant, not a secret
-	GitHubTokenEnvKey = "GITHUB_TOKEN"
 )
 
 func NewGitHubRunner(ts *apiv1.TrickSet) (rif.Runner, error) {
@@ -28,20 +21,22 @@ func NewGitHubRunner(ts *apiv1.TrickSet) (rif.Runner, error) {
 }
 
 type gitHubRunner struct {
-	ts         *apiv1.TrickSet
-	repos      *util.Stack[string]
-	client     *gh.Client
-	httpClient *http.Client
+	ts    *apiv1.TrickSet
+	repos *util.Stack[string]
+	githubcommon.GitHubCommon
 	gitcommon.GitCommon
 }
 
 func (gr *gitHubRunner) Setup(ctx context.Context) error {
 	gr.SetupCommon(ctx)
-	gr.client = gh.NewClient(gr.buildHTTPClient(ctx))
+	gr.SetupGitHubClient(ctx)
+
+	// Populate access token internally.
+	gr.SetAccessToken(gr.GetGitHubAccessToken())
 
 	org := gr.ts.Context.GitHub.Org
 
-	repos, _, repoErr := gr.client.Repositories.ListByOrg(ctx, org, &gh.RepositoryListByOrgOptions{})
+	repos, _, repoErr := gr.GetGHClient().Repositories.ListByOrg(ctx, org, &gh.RepositoryListByOrgOptions{})
 	if repoErr != nil {
 		return fmt.Errorf("unable to setup GitHub runner: %w", repoErr)
 	}
@@ -68,13 +63,13 @@ func (gr *gitHubRunner) Next(ctx context.Context) (rif.TargetEval, error) {
 		return nil, rif.ErrEndOfTargets
 	}
 
-	repoInfo, _, repoErr := gr.client.Repositories.Get(ctx,
+	repoInfo, _, repoErr := gr.GetGHClient().Repositories.Get(ctx,
 		gr.ts.Context.GitHub.Org, repoName)
 	if repoErr != nil {
 		return nil, fmt.Errorf("unable to get repo info: %w", repoErr)
 	}
 
-	vulnalerts, _, vulnErr := gr.client.Repositories.GetVulnerabilityAlerts(ctx,
+	vulnalerts, _, vulnErr := gr.GetGHClient().Repositories.GetVulnerabilityAlerts(ctx,
 		gr.ts.Context.GitHub.Org, repoName)
 
 	if vulnErr != nil {
@@ -90,28 +85,6 @@ func (gr *gitHubRunner) Next(ctx context.Context) (rif.TargetEval, error) {
 		}
 		return gr.HandleGit(ctx, grepo, gr.ts, input)
 	}, nil
-}
-
-// allows for dependency injection.
-// nolint:unused // TODO(jaosorior): write unit tests
-func (gr *gitHubRunner) setHTTPClient(c *http.Client) {
-	gr.httpClient = c
-}
-
-func (gr *gitHubRunner) buildHTTPClient(ctx context.Context) *http.Client {
-	if gr.httpClient != nil {
-		return gr.httpClient
-	}
-
-	if token := os.Getenv(GitHubTokenEnvKey); token != "" {
-		gr.SetAccessToken(token)
-		ts := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: gr.GetAccessToken()},
-		)
-		return oauth2.NewClient(ctx, ts)
-	}
-
-	return nil
 }
 
 func githubRepoToRepoRef(repo *gh.Repository) *apiv1.GitDefinition {

--- a/pkg/runner/githubcommon/githubcommon.go
+++ b/pkg/runner/githubcommon/githubcommon.go
@@ -1,0 +1,62 @@
+package githubcommon
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	gh "github.com/google/go-github/v44/github"
+	"golang.org/x/oauth2"
+)
+
+const (
+	// nolint:gosec // This is a constant, not a secret
+	GitHubTokenEnvKey = "GITHUB_TOKEN"
+)
+
+type GitHubCommon struct {
+	client     *gh.Client
+	httpClient *http.Client
+}
+
+func (gc *GitHubCommon) SetGHClient(client *gh.Client) {
+	gc.client = client
+}
+
+func (gc *GitHubCommon) GetGHClient() *gh.Client {
+	return gc.client
+}
+
+func (gc *GitHubCommon) SetupGitHubClient(ctx context.Context) {
+	gc.SetGHClient(gh.NewClient(gc.BuildHTTPClient(ctx)))
+}
+
+func (gc *GitHubCommon) GetGitHubAccessToken() string {
+	return os.Getenv(GitHubTokenEnvKey)
+}
+
+func (gc *GitHubCommon) BuildHTTPClient(ctx context.Context) *http.Client {
+	if gc.httpClient != nil {
+		return gc.httpClient
+	}
+
+	token := gc.GetGitHubAccessToken()
+	if token == "" {
+		return http.DefaultClient
+	}
+
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	return tc
+}
+
+func (gc *GitHubCommon) SetHTTPClient(client *http.Client) {
+	gc.httpClient = client
+}
+
+func (gc *GitHubCommon) GetHTTPClient() *http.Client {
+	return gc.httpClient
+}

--- a/pkg/runner/githuborgconfig/githuborgconfig.go
+++ b/pkg/runner/githuborgconfig/githuborgconfig.go
@@ -1,0 +1,127 @@
+package githuborgconfig
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	gh "github.com/google/go-github/v44/github"
+	"gopkg.in/yaml.v2"
+
+	apiv1 "github.com/lammaskoira/bark/api/v1"
+	"github.com/lammaskoira/bark/pkg/runner/githubcommon"
+	rif "github.com/lammaskoira/bark/pkg/runner/runnerinterface"
+	"github.com/lammaskoira/bark/pkg/util"
+)
+
+type gitHubOrgConfigRunner struct {
+	ts *apiv1.TrickSet
+	// We still create a stack here... but it's meant to only
+	// hold one object
+	org *util.Stack[*gh.Organization]
+	githubcommon.GitHubCommon
+	util.FileTracker
+}
+
+func NewGitHubOrgConfigRunner(ts *apiv1.TrickSet) (rif.Runner, error) {
+	return &gitHubOrgConfigRunner{
+		ts:  ts,
+		org: util.NewStack[*gh.Organization](),
+	}, nil
+}
+
+func (gr *gitHubOrgConfigRunner) Setup(ctx context.Context) error {
+	gr.SetupFileTracker()
+	gr.SetupGitHubClient(ctx)
+
+	org := gr.ts.Context.GitHubOrgConfig.Org
+	orgInfo, _, orgErr := gr.GetGHClient().Organizations.Get(ctx, org)
+	if orgErr != nil {
+		return fmt.Errorf("unable to setup GitHub runner: %w", orgErr)
+	}
+
+	gr.org.Push(orgInfo)
+
+	return nil
+}
+
+func (gr *gitHubOrgConfigRunner) Teardown(ctx context.Context) error {
+	return gr.TearDownFileTracker(ctx)
+}
+
+func (gr *gitHubOrgConfigRunner) Next(ctx context.Context) (rif.TargetEval, error) {
+	if gr.org.IsEmpty() {
+		return nil, rif.ErrEndOfTargets
+	}
+
+	org := gr.org.Pop()
+	// handles both the insertion of a nil value and the end of the stack
+	if org == nil {
+		return nil, rif.ErrEndOfTargets
+	}
+
+	return func(ctx context.Context) (*apiv1.ContextualResult, error) {
+		input := map[string]interface{}{
+			apiv1.OrgConfigInputKey: org,
+		}
+		targetDir, tderr := ioutil.TempDir("", "bark-github-org-config")
+		if tderr != nil {
+			return nil, fmt.Errorf("unable to create temp dir: %w", tderr)
+		}
+		gr.TrackFile(targetDir)
+
+		inputfile, terr := ioutil.TempFile("", "bark-input")
+		if terr != nil {
+			return nil, fmt.Errorf("failed to create input file: %w", terr)
+		}
+		defer inputfile.Close()
+		gr.TrackFile(inputfile.Name())
+
+		if eerr := json.NewEncoder(inputfile).Encode(input); eerr != nil {
+			return nil, fmt.Errorf("failed to encode input: %w", eerr)
+		}
+
+		tsfile, terr := ioutil.TempFile("", "bark-ts")
+		if terr != nil {
+			return nil, fmt.Errorf("failed to create temp trickset file: %w", terr)
+		}
+		defer tsfile.Close()
+		gr.TrackFile(tsfile.Name())
+
+		if eerr := yaml.NewEncoder(tsfile).Encode(gr.ts); eerr != nil {
+			return nil, fmt.Errorf("failed to encode input: %w", eerr)
+		}
+		var outsb, errsb bytes.Buffer
+
+		// this would be the environment
+		cmd := os.Args[0]
+
+		c := exec.Command(cmd, "bark",
+			"-i", inputfile.Name(),
+			"-t", tsfile.Name(),
+			"-x", org.GetName(),
+			"-r", targetDir,
+		)
+
+		c.Stdout = &outsb
+		c.Stderr = &errsb
+
+		if err := c.Run(); err != nil {
+			fmt.Printf("err: %s\n", err)
+		}
+
+		str := outsb.Bytes()
+
+		cr := &apiv1.ContextualResult{}
+		derr := json.Unmarshal(str, cr)
+		if derr != nil {
+			return nil, fmt.Errorf("failed to decode output: %w", derr)
+		}
+
+		return cr, nil
+	}, nil
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -10,6 +10,7 @@ import (
 	apiv1 "github.com/lammaskoira/bark/api/v1"
 	"github.com/lammaskoira/bark/pkg/runner/git"
 	"github.com/lammaskoira/bark/pkg/runner/github"
+	"github.com/lammaskoira/bark/pkg/runner/githuborgconfig"
 	rif "github.com/lammaskoira/bark/pkg/runner/runnerinterface"
 )
 
@@ -64,6 +65,8 @@ func GetContextualRunner(trickSet *apiv1.TrickSet) (rif.Runner, error) {
 		return git.NewGitRunner(trickSet)
 	case apiv1.GitHubContext:
 		return github.NewGitHubRunner(trickSet)
+	case apiv1.GitHubOrgConfigContext:
+		return githuborgconfig.NewGitHubOrgConfigRunner(trickSet)
 	}
 	return nil, fmt.Errorf("could not get runner for provider %s", trickSet.Context.Provider)
 }

--- a/pkg/util/filetracker.go
+++ b/pkg/util/filetracker.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"context"
+	"os"
+)
+
+type FileTracker struct {
+	filesToClean *Stack[string]
+}
+
+func (ft *FileTracker) SetupFileTracker() {
+	ft.filesToClean = NewStack[string]()
+}
+
+func (ft *FileTracker) TrackFile(file string) {
+	ft.filesToClean.Push(file)
+}
+
+func (ft *FileTracker) Len() int {
+	return ft.filesToClean.Len()
+}
+
+func (ft *FileTracker) TearDownFileTracker(ctx context.Context) error {
+	for !ft.filesToClean.IsEmpty() {
+		if err := os.RemoveAll(ft.filesToClean.Pop()); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/util/filetracker_test.go
+++ b/pkg/util/filetracker_test.go
@@ -1,0 +1,58 @@
+package util_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lammaskoira/bark/pkg/util"
+)
+
+func TestFileTracker(t *testing.T) {
+	t.Parallel()
+
+	ft := &util.FileTracker{}
+	ft.SetupFileTracker()
+
+	tdir := t.TempDir()
+
+	for i := 0; i < 10; i++ {
+		fpath := filepath.Join(tdir, fmt.Sprintf("testfile-%d", i))
+		_, err := os.Create(fpath)
+		require.NoError(t, err, "Create() should not return an error.")
+		ft.TrackFile(fpath)
+	}
+	require.Equal(t, 10, ft.Len(), "There should be three files tracked.")
+
+	err := ft.TearDownFileTracker(context.Background())
+	require.NoError(t, err)
+}
+
+func TestFileTrackerSucceedsTeardownWithNoTrackedFiles(t *testing.T) {
+	t.Parallel()
+
+	ft := &util.FileTracker{}
+	ft.SetupFileTracker()
+
+	err := ft.TearDownFileTracker(context.Background())
+	require.NoError(t, err)
+}
+
+// TearDown with unexistent files succeeds as the desired state is
+// for the file to be deleted.
+func TestFileTrackerSuceedsTearDownWithUnexistentFiles(t *testing.T) {
+	t.Parallel()
+
+	ft := &util.FileTracker{}
+	ft.SetupFileTracker()
+
+	fpath := t.TempDir() + "/testfile"
+	ft.TrackFile(fpath)
+
+	err := ft.TearDownFileTracker(context.Background())
+	require.NoError(t, err, "TearDownFileTracker() should not return an error.")
+}

--- a/pkg/util/stack.go
+++ b/pkg/util/stack.go
@@ -38,6 +38,12 @@ func (s *Stack[T]) Pop() T {
 	return t
 }
 
+func (s *Stack[T]) Len() int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return len(s.queue)
+}
+
 func (s *Stack[T]) IsEmpty() bool {
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/tests/data/v1/tricksets/githuborgconfig_simple_inline.yaml
+++ b/tests/data/v1/tricksets/githuborgconfig_simple_inline.yaml
@@ -1,0 +1,19 @@
+---
+# This is a test file that demonstrates a simple
+# trickset with a single rule and an inline policy
+version: v1
+context:
+  provider: githubOrgConfig
+  githubOrgConfig:
+    org: lammaskoira
+rules:
+  - name: Should have multi-factor auth enabled
+    inlinePolicy:  |
+      package bark
+
+      default allow := false
+
+      allow {
+          input.orgconfig.two_factor_requirement_enabled
+      }
+  


### PR DESCRIPTION
This adds the `githubOrgConfig` context provider, which will
query the GitHub API to allow us to evaluate policies on them.

Such a use-case would be to verify if an organization has multi-factor
auth enabled.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
