### PR TITLE
Add installed apps to `githubOrgConfig` provider input

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ retrieved from the GitHub API. The current implementation adds the following key
 * `orgconfig`: The organization configuration from the GitHub API.
   This comes from a [GET request to the GitHub API](https://docs.github.com/en/rest/reference/orgs#get-an-organization).
 
+* `apps_in_org`: It's a list of all the GitHub Apps in the organization.
+  This comes from a [GET request to the GitHub API](https://docs.github.com/en/rest/orgs/orgs#list-app-installations-for-an-organization).
+
 ### Policy language
 
 The policy format is [rego](https://www.openpolicyagent.org/docs/latest/policy-language/)

--- a/api/v1/githuborgconfig.go
+++ b/api/v1/githuborgconfig.go
@@ -7,4 +7,5 @@ type GitHubOrgConfigDefinition struct {
 
 const (
 	OrgConfigInputKey = "orgconfig"
+	AppsInOrgInputKey = "apps_in_org"
 )

--- a/tests/data/v1/tricksets/githuborgconfig_renovate.yaml
+++ b/tests/data/v1/tricksets/githuborgconfig_renovate.yaml
@@ -1,0 +1,22 @@
+---
+# This is a test file that demonstrates a simple
+# trickset that demonstrate evaluating a rule
+# that verifies if an app is installed
+version: v1
+context:
+  provider: githubOrgConfig
+  githubOrgConfig:
+    org: lammaskoira
+rules:
+  - name: Should have the renovate app installed
+    inlinePolicy:  |
+      package bark
+
+      default allow := false
+
+      allow {
+          some i
+          apps := input.apps_in_org.installations[i]
+          apps.app_slug == "renovate"
+      }
+  


### PR DESCRIPTION
This adds a new key to the rego input for the `githubOrgConfig`
provider: `apps_in_org`.

The aforementioned key lists the installed applications for the org.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
