### PR TITLE
regolib: Rename `file.readall` to `file.read`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ rules:
 
       allow {
           some i
-          workflowstr := file.readall("./.github/workflows/codeql-analysis.yml")
+          workflowstr := file.read("./.github/workflows/codeql-analysis.yml")
           workflow := yaml.unmarshal(workflowstr)
           steps := workflow.jobs.analyze.steps[i]
           contains(steps.uses, "github/codeql-action/analyze@")
@@ -189,7 +189,7 @@ contents of the repository, we need to define a couple of
 extensions to the rego language. This is done by adding the
 following builtin functions:
 
-* `file.readall(path)`: reads the file at `path` and returns its contents.
+* `file.read(path)`: reads the file at `path` and returns its contents.
 
 * `file.exists(path)`: checks if the file at `path` exists.
 

--- a/pkg/regolib/file/file.go
+++ b/pkg/regolib/file/file.go
@@ -14,7 +14,7 @@ import (
 func Library() []func(*rego.Rego) {
 	return []func(*rego.Rego){
 		Exists,
-		ReadAll,
+		Read,
 	}
 }
 
@@ -46,9 +46,9 @@ var Exists = rego.Function1(
 	},
 )
 
-var ReadAll = rego.Function1(
+var Read = rego.Function1(
 	&rego.Function{
-		Name: "file.readall",
+		Name: "file.read",
 		Decl: types.NewFunction(types.Args(types.S), types.S),
 	},
 	func(bctx rego.BuiltinContext, op1 *ast.Term) (*ast.Term, error) {

--- a/tests/data/rego/test_name.rego
+++ b/tests/data/rego/test_name.rego
@@ -3,7 +3,7 @@ package bark
 default allow := false
 
 allow {
-    contentstr := file.readall(".github/workflows/test.yml")
+    contentstr := file.read(".github/workflows/test.yml")
     contents := yaml.unmarshal(contentstr)
     contents.name == "test"
 }

--- a/tests/data/v1/tricksets/codeql_analysis.yaml
+++ b/tests/data/v1/tricksets/codeql_analysis.yaml
@@ -16,7 +16,7 @@ rules:
 
       allow {
           some i
-          workflowstr := file.readall("./.github/workflows/codeql-analysis.yml")
+          workflowstr := file.read("./.github/workflows/codeql-analysis.yml")
           workflow := yaml.unmarshal(workflowstr)
           steps := workflow.jobs.analyze.steps[i]
           contains(steps.uses, "github/codeql-action/analyze@")


### PR DESCRIPTION
This makes the function name a little more general and will help us
avoid confusion in the future.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
